### PR TITLE
Add test ConstantOfShape with node structure as found in a model in t…

### DIFF
--- a/crates/onnx-ir/src/node/constant_of_shape.rs
+++ b/crates/onnx-ir/src/node/constant_of_shape.rs
@@ -272,4 +272,21 @@ mod tests {
             _ => panic!("Expected Tensor output for Shape(1) input with default Float32 value"),
         }
     }
+
+    #[test]
+    fn test_no_static_shapes_with_value_attr() {
+        let mut node = NodeBuilder::new(NodeType::ConstantOfShape, "constantofshape1")
+            .input_tensor_i64("constant180_out1", 1, None)
+            .output_default("/model/encoder/patch_encoder/ConstantOfShape_output_0")
+            .attr_tensor(
+                "value",
+                TensorData {
+                    data: Data::Int64s(vec![1]),
+                    shape: vec![1],
+                },
+            )
+            .build();
+
+        constant_of_shape_update_output(&mut node);
+    }
 }


### PR DESCRIPTION
…he wild. Should therefore pass, but currently fails

Context: https://discordapp.com/channels/1038839012602941528/1091796857996451942/1405609521568677990


This is how the real model fails:

<img width="855" height="867" alt="image" src="https://github.com/user-attachments/assets/ca8639ee-6ad8-4217-8b9a-dc091e16c295" />


The test fails in the same way except the "passed" field is true instead of false. Not sure if that matters. 
