### PR TITLE
Replace CastDTypeAdapter with HalfPrecisionAdapter

### DIFF
--- a/burn-book/src/saving-and-loading.md
+++ b/burn-book/src/saving-and-loading.md
@@ -323,6 +323,40 @@ let mut store = BurnpackStore::from_file("large_model.bpk")
 model.load_from(&mut store)?;
 ```
 
+#### Half-Precision Storage
+
+Save models at half precision (F16) to reduce file size by ~50%, then load back at full precision:
+
+```rust, ignore
+use burn_store::{ModuleSnapshot, BurnpackStore, HalfPrecisionAdapter};
+
+let adapter = HalfPrecisionAdapter::new();
+
+// Save: F32 -> F16 (same adapter for both directions)
+let mut store = BurnpackStore::from_file("model_f16.bpk")
+    .with_to_adapter(adapter.clone());
+model.save_into(&mut store)?;
+
+// Load: F16 -> F32
+let mut store = BurnpackStore::from_file("model_f16.bpk")
+    .with_from_adapter(adapter);
+model.load_from(&mut store)?;
+```
+
+By default, weights in Linear, Embedding, Conv\*, LayerNorm, GroupNorm, InstanceNorm, RmsNorm, and
+PRelu modules are converted. BatchNorm is excluded because its running variance can underflow in
+F16. Customize with `with_module()` and `without_module()`:
+
+```rust, ignore
+// Keep LayerNorm at full precision
+let adapter = HalfPrecisionAdapter::new()
+    .without_module("LayerNorm");
+
+// Add a custom module to the conversion set
+let adapter = HalfPrecisionAdapter::new()
+    .with_module("CustomLayer");
+```
+
 #### Direct Tensor Access
 
 Inspect tensors without loading into a model:
@@ -371,6 +405,7 @@ model2.apply(snapshots, Some(filter), None, false);
 |               | `remap(KeyRemapper)`           | Complex remapping rules      |
 | **Adapters**  | `with_from_adapter(adapter)`   | Loading transformations      |
 |               | `with_to_adapter(adapter)`     | Saving transformations       |
+|               | `HalfPrecisionAdapter::new()`  | F32/F16 mixed-precision      |
 | **Config**    | `allow_partial(bool)`          | Continue on missing tensors  |
 |               | `with_top_level_key(key)`      | Access nested dict (PyTorch) |
 |               | `skip_enum_variants(bool)`     | Skip enum variants in paths  |

--- a/crates/burn-store/README.md
+++ b/crates/burn-store/README.md
@@ -23,12 +23,14 @@ interoperability, and advanced tensor management.
 - **Flexible Filtering** - Load/save specific model subsets with regex, exact paths, or custom
   predicates
 - **Tensor Remapping** - Rename tensors during load/save for framework compatibility
+- **Half-Precision Storage** - Automatic F32/F16 conversion with smart defaults for reduced model
+  file size
 - **No-std Support** - Burnpack and SafeTensors formats available in embedded and WASM environments
 
 ## Quick Start
 
 ```rust
-use burn_store::{ModuleSnapshot, PytorchStore, SafetensorsStore, BurnpackStore};
+use burn_store::{ModuleSnapshot, PytorchStore, SafetensorsStore, BurnpackStore, HalfPrecisionAdapter};
 
 // Load from PyTorch
 let mut store = PytorchStore::from_file("model.pt");
@@ -42,6 +44,17 @@ model.load_from(&mut store)?;
 // Save to Burnpack
 let mut store = BurnpackStore::from_file("model.bpk");
 model.save_into(&mut store)?;
+
+// Save with half-precision (F32 -> F16, ~50% smaller files)
+let adapter = HalfPrecisionAdapter::new();
+let mut store = BurnpackStore::from_file("model_f16.bpk")
+    .with_to_adapter(adapter.clone());
+model.save_into(&mut store)?;
+
+// Load half-precision back (F16 -> F32, same adapter)
+let mut store = BurnpackStore::from_file("model_f16.bpk")
+    .with_from_adapter(adapter);
+model.load_from(&mut store)?;
 ```
 
 ## Documentation

--- a/crates/burn-store/examples/half_precision.rs
+++ b/crates/burn-store/examples/half_precision.rs
@@ -1,0 +1,88 @@
+//! Example: Save and load a model with half-precision (F32 <-> F16)
+//!
+//! Demonstrates using HalfPrecisionAdapter to automatically convert between
+//! F32 and F16 during saving/loading. The same adapter instance handles both
+//! directions.
+//!
+//! Usage:
+//!   cargo run -p burn-store --example half_precision
+
+use burn_core as burn;
+use burn_core::module::Module;
+use burn_ndarray::NdArray;
+use burn_nn::{LayerNorm, LayerNormConfig, Linear, LinearConfig};
+use burn_store::{BurnpackStore, HalfPrecisionAdapter, ModuleSnapshot};
+use burn_tensor::backend::Backend;
+
+// A model with mixed layer types to show selective conversion
+#[derive(Module, Debug)]
+struct DemoModel<B: Backend> {
+    linear1: Linear<B>,
+    norm: LayerNorm<B>,
+    linear2: Linear<B>,
+}
+
+impl<B: Backend> DemoModel<B> {
+    fn new(device: &B::Device) -> Self {
+        Self {
+            linear1: LinearConfig::new(128, 64).init(device),
+            norm: LayerNormConfig::new(64).init(device),
+            linear2: LinearConfig::new(64, 10).init(device),
+        }
+    }
+}
+
+fn main() {
+    type B = NdArray<f32>;
+    let device = Default::default();
+    let model = DemoModel::<B>::new(&device);
+
+    // 1) Save at full F32 precision (baseline)
+    let path_f32 = "/tmp/model_f32";
+    let mut store = BurnpackStore::from_file(path_f32).overwrite(true);
+    model.save_into(&mut store).expect("Failed to save F32");
+    let size_f32 = std::fs::metadata(format!("{}.bpk", path_f32))
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    // 2) Save with default half-precision (all default modules get F16)
+    let path_f16 = "/tmp/model_f16";
+    let adapter = HalfPrecisionAdapter::new();
+    let mut store = BurnpackStore::from_file(path_f16)
+        .overwrite(true)
+        .with_to_adapter(adapter.clone());
+    model.save_into(&mut store).expect("Failed to save F16");
+    let size_f16 = std::fs::metadata(format!("{}.bpk", path_f16))
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    // 3) Save with without_module: keep LayerNorm at F32
+    let path_mixed = "/tmp/model_mixed";
+    let adapter_no_norm = HalfPrecisionAdapter::new().without_module("LayerNorm");
+    let mut store = BurnpackStore::from_file(path_mixed)
+        .overwrite(true)
+        .with_to_adapter(adapter_no_norm);
+    model.save_into(&mut store).expect("Failed to save mixed");
+    let size_mixed = std::fs::metadata(format!("{}.bpk", path_mixed))
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    println!("F32 (full precision):    {} bytes", size_f32);
+    println!("F16 (default modules):   {} bytes", size_f16);
+    println!("Mixed (norm stays F32):  {} bytes", size_mixed);
+    println!(
+        "F16 savings: {:.1}%",
+        (1.0 - size_f16 as f64 / size_f32 as f64) * 100.0
+    );
+
+    // 4) Round-trip: load the F16 file back to F32 with the same adapter
+    let mut load_store = BurnpackStore::from_file(path_f16)
+        .with_from_adapter(adapter)
+        .validate(false);
+    let mut model2 = DemoModel::<B>::new(&device);
+    let result = model2.load_from(&mut load_store).expect("Failed to load");
+    println!(
+        "\nRound-trip loaded {} tensors successfully",
+        result.applied.len()
+    );
+}

--- a/crates/burn-store/src/adapter.rs
+++ b/crates/burn-store/src/adapter.rs
@@ -1,8 +1,9 @@
-//! Module adapters for transforming tensors between different formats
+//! Module adapters for transforming tensor snapshots during save/load
 //!
-//! This module provides adapters that handle differences between PyTorch and Burn:
-//! - Linear layer weight transposition
-//! - Normalization parameter naming (weight/bias vs gamma/beta)
+//! This module provides adapters for:
+//! - PyTorch/Burn format conversion (weight transposition, parameter renaming)
+//! - Mixed-precision storage (F32/F16 dtype casting via [`HalfPrecisionAdapter`])
+//! - Adapter chaining for composing multiple transformations
 
 use crate::TensorSnapshot;
 
@@ -12,7 +13,8 @@ use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;
 
-use burn_tensor::TensorData;
+use burn_tensor::{DType, TensorData};
+use hashbrown::HashSet;
 
 // Module type names as they appear in the container_type field
 // These come from the Module derive macro which uses stringify! on the struct name
@@ -23,6 +25,17 @@ mod module_names {
     pub const BATCH_NORM: &str = "Struct:BatchNorm";
     pub const LAYER_NORM: &str = "Struct:LayerNorm";
     pub const GROUP_NORM: &str = "Struct:GroupNorm";
+    pub const EMBEDDING: &str = "Struct:Embedding";
+    pub const CONV1D: &str = "Struct:Conv1d";
+    pub const CONV2D: &str = "Struct:Conv2d";
+    pub const CONV3D: &str = "Struct:Conv3d";
+    pub const CONV_TRANSPOSE1D: &str = "Struct:ConvTranspose1d";
+    pub const CONV_TRANSPOSE2D: &str = "Struct:ConvTranspose2d";
+    pub const CONV_TRANSPOSE3D: &str = "Struct:ConvTranspose3d";
+    pub const DEFORM_CONV2D: &str = "Struct:DeformConv2d";
+    pub const INSTANCE_NORM: &str = "Struct:InstanceNorm";
+    pub const RMS_NORM: &str = "Struct:RmsNorm";
+    pub const PRELU: &str = "Struct:PRelu";
 }
 
 /// Trait for adapting tensor snapshots between different module formats
@@ -132,6 +145,158 @@ pub struct IdentityAdapter;
 impl ModuleAdapter for IdentityAdapter {
     fn adapt(&self, snapshot: &TensorSnapshot) -> TensorSnapshot {
         snapshot.clone()
+    }
+
+    fn clone_box(&self) -> Box<dyn ModuleAdapter> {
+        Box::new(self.clone())
+    }
+}
+
+/// Returns the default set of module types that `HalfPrecisionAdapter` converts.
+///
+/// Includes: Linear, Embedding, all Conv variants, LayerNorm, GroupNorm,
+/// InstanceNorm, RmsNorm, PRelu.
+///
+/// Excludes BatchNorm by default because `running_var` underflows in F16.
+fn default_half_precision_modules() -> HashSet<String> {
+    let modules = [
+        module_names::LINEAR,
+        module_names::EMBEDDING,
+        module_names::CONV1D,
+        module_names::CONV2D,
+        module_names::CONV3D,
+        module_names::CONV_TRANSPOSE1D,
+        module_names::CONV_TRANSPOSE2D,
+        module_names::CONV_TRANSPOSE3D,
+        module_names::DEFORM_CONV2D,
+        module_names::LAYER_NORM,
+        module_names::GROUP_NORM,
+        module_names::INSTANCE_NORM,
+        module_names::RMS_NORM,
+        module_names::PRELU,
+    ];
+    modules.iter().map(|s| s.to_string()).collect()
+}
+
+/// Adapter for mixed-precision (F32/F16) model storage.
+///
+/// Auto-detects conversion direction from the snapshot's dtype:
+/// - F32 source -> cast to F16 (typical for saving)
+/// - F16 source -> cast to F32 (typical for loading)
+/// - Other dtypes -> passed through unchanged
+///
+/// The same instance works for both `with_to_adapter` (save) and `with_from_adapter` (load).
+///
+/// By default, converts weights in: Linear, Embedding, Conv*, LayerNorm, GroupNorm,
+/// InstanceNorm, RmsNorm, PRelu. BatchNorm is excluded because `running_var` underflows in F16.
+///
+/// # Examples
+///
+/// Default usage (same adapter for save and load):
+/// ```rust
+/// # use burn_store::HalfPrecisionAdapter;
+/// let adapter = HalfPrecisionAdapter::new();
+/// // store.with_to_adapter(adapter.clone());  // F32 -> F16 on save
+/// // store.with_from_adapter(adapter);        // F16 -> F32 on load
+/// ```
+///
+/// Exclude a module type:
+/// ```rust
+/// # use burn_store::HalfPrecisionAdapter;
+/// let adapter = HalfPrecisionAdapter::new()
+///     .without_module("LayerNorm");
+/// ```
+///
+/// Add a custom module type:
+/// ```rust
+/// # use burn_store::HalfPrecisionAdapter;
+/// let adapter = HalfPrecisionAdapter::new()
+///     .with_module("CustomLayer");
+/// ```
+#[derive(Debug, Clone)]
+pub struct HalfPrecisionAdapter {
+    modules: HashSet<String>,
+}
+
+impl HalfPrecisionAdapter {
+    /// Create a new adapter with the default set of modules.
+    pub fn new() -> Self {
+        Self {
+            modules: default_half_precision_modules(),
+        }
+    }
+
+    /// Add a module type to convert. Accepts both short (`"MyLayer"`) and
+    /// qualified (`"Struct:MyLayer"`) forms.
+    pub fn with_module(mut self, module_type: impl Into<String>) -> Self {
+        let name = module_type.into();
+        if name.contains(':') {
+            self.modules.insert(name);
+        } else {
+            self.modules.insert(format!("Struct:{}", name));
+        }
+        self
+    }
+
+    /// Remove a module type from conversion. Accepts both short and qualified forms.
+    pub fn without_module(mut self, module_type: impl Into<String>) -> Self {
+        let name = module_type.into();
+        let key = if name.contains(':') {
+            name
+        } else {
+            format!("Struct:{}", name)
+        };
+        debug_assert!(
+            self.modules.contains(&key),
+            "without_module called with '{}' which is not in the module set",
+            key
+        );
+        self.modules.remove(&key);
+        self
+    }
+
+    /// Check whether the tensor belongs to a module that should be converted.
+    fn should_convert(&self, snapshot: &TensorSnapshot) -> bool {
+        snapshot
+            .module_type()
+            .is_some_and(|mt| self.modules.contains(&mt))
+    }
+}
+
+impl Default for HalfPrecisionAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ModuleAdapter for HalfPrecisionAdapter {
+    fn adapt(&self, snapshot: &TensorSnapshot) -> TensorSnapshot {
+        // Determine target dtype from source: F32 -> F16, F16 -> F32, anything else -> skip
+        let target_dtype = match snapshot.dtype {
+            DType::F32 => DType::F16,
+            DType::F16 => DType::F32,
+            _ => return snapshot.clone(),
+        };
+
+        if !self.should_convert(snapshot) {
+            return snapshot.clone();
+        }
+
+        let original_data_fn = snapshot.clone_data_fn();
+
+        let cast_data_fn = Rc::new(move || {
+            let data = original_data_fn()?;
+            Ok(data.convert_dtype(target_dtype))
+        });
+
+        TensorSnapshot::from_closure(
+            cast_data_fn,
+            target_dtype,
+            snapshot.shape.clone(),
+            snapshot.path_stack.clone().unwrap_or_default(),
+            snapshot.container_stack.clone().unwrap_or_default(),
+            snapshot.tensor_id.unwrap_or_default(),
+        )
     }
 
     fn clone_box(&self) -> Box<dyn ModuleAdapter> {
@@ -356,16 +521,30 @@ mod tests {
     #[test]
     fn test_module_names_match_burn_nn() {
         // If these types are renamed or moved in `burn-nn`, this test will fail to compile.
-        // This use statement replicates the previous check/alarm system.
         #[allow(unused_imports)]
-        use burn_nn::{BatchNorm, GroupNorm, LayerNorm, Linear};
+        use burn_nn::{
+            BatchNorm, Embedding, GroupNorm, InstanceNorm, LayerNorm, Linear, PRelu, RmsNorm,
+            conv::{
+                Conv1d, Conv2d, Conv3d, ConvTranspose1d, ConvTranspose2d, ConvTranspose3d,
+                DeformConv2d,
+            },
+        };
 
-        // These assert statements work as extra checks that should remind maintainers more
-        // clearly that the hardcoded strings needs get updated.
         assert_eq!(module_names::LINEAR, "Struct:Linear");
         assert_eq!(module_names::BATCH_NORM, "Struct:BatchNorm");
         assert_eq!(module_names::LAYER_NORM, "Struct:LayerNorm");
         assert_eq!(module_names::GROUP_NORM, "Struct:GroupNorm");
+        assert_eq!(module_names::EMBEDDING, "Struct:Embedding");
+        assert_eq!(module_names::CONV1D, "Struct:Conv1d");
+        assert_eq!(module_names::CONV2D, "Struct:Conv2d");
+        assert_eq!(module_names::CONV3D, "Struct:Conv3d");
+        assert_eq!(module_names::CONV_TRANSPOSE1D, "Struct:ConvTranspose1d");
+        assert_eq!(module_names::CONV_TRANSPOSE2D, "Struct:ConvTranspose2d");
+        assert_eq!(module_names::CONV_TRANSPOSE3D, "Struct:ConvTranspose3d");
+        assert_eq!(module_names::DEFORM_CONV2D, "Struct:DeformConv2d");
+        assert_eq!(module_names::INSTANCE_NORM, "Struct:InstanceNorm");
+        assert_eq!(module_names::RMS_NORM, "Struct:RmsNorm");
+        assert_eq!(module_names::PRELU, "Struct:PRelu");
     }
 
     fn create_test_snapshot(path: &str, shape: Vec<usize>, container_type: &str) -> TensorSnapshot {
@@ -659,5 +838,176 @@ mod tests {
         let boxed = chain.clone_box();
         let alt = boxed.get_alternative_param_name("gamma", module_names::LAYER_NORM);
         assert_eq!(alt.as_deref(), Some("weight"));
+    }
+
+    #[test]
+    fn test_half_precision_f32_to_f16() {
+        let adapter = HalfPrecisionAdapter::new();
+        let snapshot = create_test_snapshot("fc.weight", vec![2, 3], module_names::LINEAR);
+
+        let adapted = adapter.adapt(&snapshot);
+        assert_eq!(adapted.dtype, DType::F16);
+        assert_eq!(adapted.shape, vec![2, 3]);
+
+        let data = adapted.to_data().unwrap();
+        assert_eq!(data.dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_f16_to_f32() {
+        let adapter = HalfPrecisionAdapter::new();
+
+        // Create an F16 snapshot
+        let values = vec![1.0f32; 6];
+        let data = TensorData::new(values, vec![2, 3]).convert_dtype(DType::F16);
+        let path_parts = vec!["fc".to_string(), "weight".to_string()];
+        let snapshot = TensorSnapshot::from_closure(
+            Rc::new(move || Ok(data.clone())),
+            DType::F16,
+            vec![2, 3],
+            path_parts,
+            vec![module_names::LINEAR.to_string()],
+            burn_core::module::ParamId::new(),
+        );
+
+        let adapted = adapter.adapt(&snapshot);
+        assert_eq!(adapted.dtype, DType::F32);
+    }
+
+    #[test]
+    fn test_half_precision_skips_batch_norm() {
+        let adapter = HalfPrecisionAdapter::new();
+
+        // BatchNorm is excluded by default
+        let snapshot = create_test_snapshot("norm.weight", vec![10], module_names::BATCH_NORM);
+        let adapted = adapter.adapt(&snapshot);
+        assert_eq!(adapted.dtype, DType::F32); // unchanged
+    }
+
+    #[test]
+    fn test_half_precision_converts_default_modules() {
+        let adapter = HalfPrecisionAdapter::new();
+
+        // Linear
+        let snapshot = create_test_snapshot("fc.weight", vec![2, 3], module_names::LINEAR);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+
+        // Embedding
+        let snapshot = create_test_snapshot("emb.weight", vec![100, 64], module_names::EMBEDDING);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+
+        // Conv2d
+        let snapshot = create_test_snapshot("conv.weight", vec![3, 3, 3, 3], module_names::CONV2D);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+
+        // LayerNorm (included by default)
+        let snapshot = create_test_snapshot("norm.gamma", vec![10], module_names::LAYER_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+
+        // GroupNorm
+        let snapshot = create_test_snapshot("gn.gamma", vec![10], module_names::GROUP_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+
+        // RmsNorm
+        let snapshot = create_test_snapshot("rms.weight", vec![10], module_names::RMS_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_without_module() {
+        let adapter = HalfPrecisionAdapter::new().without_module("LayerNorm");
+
+        // LayerNorm removed from conversion set
+        let snapshot = create_test_snapshot("norm.gamma", vec![10], module_names::LAYER_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F32);
+
+        // Linear still converted
+        let snapshot = create_test_snapshot("fc.weight", vec![2, 3], module_names::LINEAR);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_with_module() {
+        let adapter = HalfPrecisionAdapter::new().with_module("CustomLayer");
+
+        // Custom module should now be converted
+        let snapshot = create_test_snapshot("custom.weight", vec![5], "Struct:CustomLayer");
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_with_qualified_name() {
+        let adapter = HalfPrecisionAdapter::new().with_module("Struct:CustomLayer");
+
+        let snapshot = create_test_snapshot("custom.weight", vec![5], "Struct:CustomLayer");
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_chain() {
+        let adapter = PyTorchToBurnAdapter.chain(HalfPrecisionAdapter::new());
+
+        let snapshot = create_test_snapshot("fc.weight", vec![10, 5], module_names::LINEAR);
+        let adapted = adapter.adapt(&snapshot);
+
+        // Should be both transposed and cast
+        assert_eq!(adapted.shape, vec![5, 10]);
+        assert_eq!(adapted.dtype, DType::F16);
+    }
+
+    #[test]
+    fn test_half_precision_skips_no_container() {
+        let adapter = HalfPrecisionAdapter::new();
+        let mut snapshot = create_test_snapshot("fc.weight", vec![2, 3], module_names::LINEAR);
+        snapshot.container_stack = None;
+
+        // No module type info: skip
+        let adapted = adapter.adapt(&snapshot);
+        assert_eq!(adapted.dtype, DType::F32);
+    }
+
+    #[test]
+    fn test_half_precision_skips_non_float() {
+        use burn_tensor::quantization::QuantScheme;
+
+        let adapter = HalfPrecisionAdapter::new();
+
+        // QFloat source: skip
+        let qfloat_dtype = DType::QFloat(QuantScheme::default());
+        let snapshot = create_test_snapshot("fc.weight", vec![2, 3], module_names::LINEAR);
+        let qfloat_snapshot = TensorSnapshot::from_closure(
+            snapshot.clone_data_fn(),
+            qfloat_dtype,
+            snapshot.shape.clone(),
+            snapshot.path_stack.clone().unwrap_or_default(),
+            snapshot.container_stack.clone().unwrap_or_default(),
+            snapshot.tensor_id.unwrap_or_default(),
+        );
+        let adapted = adapter.adapt(&qfloat_snapshot);
+        assert_eq!(adapted.dtype, qfloat_dtype);
+    }
+
+    #[test]
+    fn test_half_precision_default_module_count() {
+        let adapter = HalfPrecisionAdapter::new();
+        // 14 modules: Linear, Embedding, Conv1d-3d, ConvTranspose1d-3d,
+        // DeformConv2d, LayerNorm, GroupNorm, InstanceNorm, RmsNorm, PRelu
+        assert_eq!(adapter.modules.len(), 14);
+    }
+
+    #[test]
+    fn test_half_precision_without_module_qualified() {
+        let adapter = HalfPrecisionAdapter::new().without_module("Struct:LayerNorm");
+
+        let snapshot = create_test_snapshot("norm.gamma", vec![10], module_names::LAYER_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F32);
+    }
+
+    #[test]
+    fn test_half_precision_with_module_batch_norm_opt_in() {
+        let adapter = HalfPrecisionAdapter::new().with_module("BatchNorm");
+
+        let snapshot = create_test_snapshot("bn.weight", vec![10], module_names::BATCH_NORM);
+        assert_eq!(adapter.adapt(&snapshot).dtype, DType::F16);
     }
 }

--- a/crates/burn-store/src/burnpack/store.rs
+++ b/crates/burn-store/src/burnpack/store.rs
@@ -6,7 +6,10 @@ use super::writer::BurnpackWriter;
 #[cfg(feature = "std")]
 use crate::KeyRemapper;
 use crate::burnpack::base::BurnpackError;
-use crate::{ModuleSnapshot, ModuleStore, PathFilter, TensorSnapshot};
+use crate::{
+    IdentityAdapter, ModuleAdapter, ModuleSnapshot, ModuleStore, PathFilter, TensorSnapshot,
+};
+use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::format;
 use alloc::string::String;
@@ -46,6 +49,10 @@ pub struct BurnpackStore {
     /// Key remapper for tensor name transformations
     #[cfg(feature = "std")]
     remapper: KeyRemapper,
+    /// Adapter applied when loading (source -> Burn)
+    from_adapter: Box<dyn ModuleAdapter>,
+    /// Adapter applied when saving (Burn -> target)
+    to_adapter: Box<dyn ModuleAdapter>,
     /// Writer for saving
     writer: Option<BurnpackWriter>,
     /// Reader for loading
@@ -103,6 +110,8 @@ impl BurnpackStore {
             auto_extension: true,
             #[cfg(feature = "std")]
             remapper: KeyRemapper::new(),
+            from_adapter: Box::new(IdentityAdapter),
+            to_adapter: Box::new(IdentityAdapter),
             writer: None,
             reader: None,
             snapshots_cache: None,
@@ -123,6 +132,8 @@ impl BurnpackStore {
             auto_extension: false, // Not used for bytes mode
             #[cfg(feature = "std")]
             remapper: KeyRemapper::new(),
+            from_adapter: Box::new(IdentityAdapter),
+            to_adapter: Box::new(IdentityAdapter),
             writer: None,
             reader: None,
             snapshots_cache: None,
@@ -162,6 +173,8 @@ impl BurnpackStore {
             auto_extension: false,
             #[cfg(feature = "std")]
             remapper: KeyRemapper::new(),
+            from_adapter: Box::new(IdentityAdapter),
+            to_adapter: Box::new(IdentityAdapter),
             writer: None,
             reader: None,
             snapshots_cache: None,
@@ -256,6 +269,18 @@ impl BurnpackStore {
     #[cfg(feature = "std")]
     pub fn auto_extension(mut self, enable: bool) -> Self {
         self.auto_extension = enable;
+        self
+    }
+
+    /// Set the adapter for loading tensors (converting from source format to Burn).
+    pub fn with_from_adapter(mut self, adapter: impl ModuleAdapter + 'static) -> Self {
+        self.from_adapter = Box::new(adapter);
+        self
+    }
+
+    /// Set the adapter for saving tensors (converting from Burn to target format).
+    pub fn with_to_adapter(mut self, adapter: impl ModuleAdapter + 'static) -> Self {
+        self.to_adapter = Box::new(adapter);
         self
     }
 
@@ -378,8 +403,8 @@ impl ModuleStore for BurnpackStore {
         self.snapshots_cache = None;
         self.reader = None;
 
-        // Collect snapshots from module
-        let snapshots = module.collect(self.filter.clone(), None, false);
+        // Collect snapshots from module with adapter
+        let snapshots = module.collect(self.filter.clone(), Some(self.to_adapter.clone()), false);
 
         // Initialize writer with snapshots
         let mut writer = BurnpackWriter::new(snapshots);
@@ -435,7 +460,12 @@ impl ModuleStore for BurnpackStore {
         // Apply all snapshots at once to the module
         // Burnpack is Burn's native format, so no enum variant skipping needed
         // Filter is applied here during apply, not during cache population
-        let result = module.apply(snapshots, self.filter.clone(), None, false);
+        let result = module.apply(
+            snapshots,
+            self.filter.clone(),
+            Some(self.from_adapter.clone()),
+            false,
+        );
 
         // Validate if needed
         if self.validate && !result.errors.is_empty() {

--- a/crates/burn-store/src/burnpack/tests/store.rs
+++ b/crates/burn-store/src/burnpack/tests/store.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "std")]
 use crate::KeyRemapper;
 use crate::burnpack::store::BurnpackStore;
-use crate::{ModuleSnapshot, ModuleStore, PathFilter};
+use crate::{ModuleAdapter, ModuleSnapshot, ModuleStore, PathFilter};
 
 use burn_core as burn;
 use burn_core::module::{Module, Param};
@@ -1120,6 +1120,200 @@ fn test_store_quantized_module_round_trip() {
         .to_data()
         .expect("Failed to load tensor data");
     assert_eq!(weight_data.shape, vec![512, 512]);
+}
+
+/// Test HalfPrecisionAdapter bidirectional round-trip: same adapter for save and load.
+#[test]
+fn test_store_half_precision_round_trip() {
+    use crate::HalfPrecisionAdapter;
+    use burn_nn::{Linear, LinearConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct HalfModel<B: Backend> {
+        linear: Linear<B>,
+    }
+
+    let device = Default::default();
+    let model = HalfModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+    };
+
+    // Save with HalfPrecisionAdapter (F32 -> F16)
+    let adapter = HalfPrecisionAdapter::new();
+    let mut save_store = BurnpackStore::from_bytes(None).with_to_adapter(adapter.clone());
+    save_store.collect_from(&model).unwrap();
+    let bytes = save_store.get_bytes().unwrap();
+
+    // Verify stored tensors are F16
+    let mut inspect_store = BurnpackStore::from_bytes(Some(bytes.clone()));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (_, snapshot) in snapshots.iter() {
+        assert_eq!(snapshot.dtype, DType::F16, "Expected F16 in stored data");
+    }
+
+    // Load back with same adapter instance (F16 -> F32)
+    let mut load_store = BurnpackStore::from_bytes(Some(bytes))
+        .with_from_adapter(adapter)
+        .validate(false);
+    let mut model2 = HalfModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+    };
+    let result = load_store.apply_to(&mut model2).unwrap();
+    assert!(result.is_success());
+
+    // Verify values are close (F32 -> F16 -> F32 has rounding)
+    let w1 = model.linear.weight.val().to_data().to_vec::<f32>().unwrap();
+    let w2 = model2
+        .linear
+        .weight
+        .val()
+        .to_data()
+        .to_vec::<f32>()
+        .unwrap();
+    for (a, b) in w1.iter().zip(w2.iter()) {
+        assert!(
+            (a - b).abs() < 0.01,
+            "Weight values differ too much after F16 round-trip: {} vs {}",
+            a,
+            b
+        );
+    }
+}
+
+/// Test HalfPrecisionAdapter: BatchNorm excluded by default.
+#[test]
+fn test_store_half_precision_batch_norm_excluded() {
+    use crate::HalfPrecisionAdapter;
+    use burn_nn::{BatchNorm, BatchNormConfig, Linear, LinearConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct BnModel<B: Backend> {
+        linear: Linear<B>,
+        bn: BatchNorm<B>,
+    }
+
+    let device = Default::default();
+    let model = BnModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+        bn: BatchNormConfig::new(2).init(&device),
+    };
+
+    let adapter = HalfPrecisionAdapter::new();
+    let mut save_store = BurnpackStore::from_bytes(None).with_to_adapter(adapter);
+    save_store.collect_from(&model).unwrap();
+    let bytes = save_store.get_bytes().unwrap();
+
+    // Verify: Linear tensors are F16, BatchNorm tensors remain F32
+    let mut inspect_store = BurnpackStore::from_bytes(Some(bytes));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (name, snapshot) in snapshots.iter() {
+        if name.starts_with("linear") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F16,
+                "Linear tensor '{}' should be F16",
+                name
+            );
+        } else if name.starts_with("bn") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F32,
+                "BatchNorm tensor '{}' should stay F32",
+                name
+            );
+        }
+    }
+}
+
+/// Test HalfPrecisionAdapter with without_module customization.
+#[test]
+fn test_store_half_precision_without_module() {
+    use crate::HalfPrecisionAdapter;
+    use burn_nn::{LayerNorm, LayerNormConfig, Linear, LinearConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct MixedModel<B: Backend> {
+        linear: Linear<B>,
+        norm: LayerNorm<B>,
+    }
+
+    let device = Default::default();
+    let model = MixedModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+        norm: LayerNormConfig::new(2).init(&device),
+    };
+
+    // Remove LayerNorm from half-precision conversion
+    let adapter = HalfPrecisionAdapter::new().without_module("LayerNorm");
+    let mut save_store = BurnpackStore::from_bytes(None).with_to_adapter(adapter);
+    save_store.collect_from(&model).unwrap();
+    let bytes = save_store.get_bytes().unwrap();
+
+    let mut inspect_store = BurnpackStore::from_bytes(Some(bytes));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (name, snapshot) in snapshots.iter() {
+        if name.starts_with("linear") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F16,
+                "Linear tensor '{}' should be F16",
+                name
+            );
+        } else if name.starts_with("norm") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F32,
+                "LayerNorm tensor '{}' should stay F32",
+                name
+            );
+        }
+    }
+}
+
+/// Test HalfPrecisionAdapter chained with PyTorch adapter.
+#[test]
+fn test_store_half_precision_chained_with_pytorch() {
+    use crate::{HalfPrecisionAdapter, PyTorchToBurnAdapter};
+    use burn_nn::{Linear, LinearConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct ChainModel<B: Backend> {
+        linear: Linear<B>,
+    }
+
+    let device = Default::default();
+    let model = ChainModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+    };
+
+    // Save with chained adapter: BurnToPyTorch then half-precision
+    let adapter = crate::BurnToPyTorchAdapter.chain(HalfPrecisionAdapter::new());
+    let mut save_store = BurnpackStore::from_bytes(None).with_to_adapter(adapter);
+    save_store.collect_from(&model).unwrap();
+    let bytes = save_store.get_bytes().unwrap();
+
+    // Verify stored tensors are F16 and transposed
+    let mut inspect_store = BurnpackStore::from_bytes(Some(bytes.clone()));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    let weight = snapshots.get("linear.weight").unwrap();
+    assert_eq!(weight.dtype, DType::F16);
+    // Weight should be transposed: [4, 2] original -> [2, 4] after BurnToPyTorch
+    assert_eq!(weight.shape, vec![2, 4]);
+
+    // Load back with reverse chain: half-precision (F16 -> F32) then PyTorchToBurn
+    let adapter = HalfPrecisionAdapter::new().chain(PyTorchToBurnAdapter);
+    let mut load_store = BurnpackStore::from_bytes(Some(bytes))
+        .with_from_adapter(adapter)
+        .validate(false);
+    let mut model2 = ChainModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+    };
+    let result = load_store.apply_to(&mut model2).unwrap();
+    assert!(result.is_success());
 }
 
 /// Test storing quantized weights with block-level quantization.

--- a/crates/burn-store/src/lib.rs
+++ b/crates/burn-store/src/lib.rs
@@ -86,7 +86,8 @@ mod tensor_snapshot;
 mod traits;
 
 pub use adapter::{
-    BurnToPyTorchAdapter, ChainAdapter, IdentityAdapter, ModuleAdapter, PyTorchToBurnAdapter,
+    BurnToPyTorchAdapter, ChainAdapter, HalfPrecisionAdapter, IdentityAdapter, ModuleAdapter,
+    PyTorchToBurnAdapter,
 };
 pub use applier::Applier;
 pub use apply_result::{ApplyError, ApplyResult};

--- a/crates/burn-store/src/safetensors/tests/adapter.rs
+++ b/crates/burn-store/src/safetensors/tests/adapter.rs
@@ -1,6 +1,8 @@
 use burn_core as burn;
 
-use crate::{BurnToPyTorchAdapter, ModuleSnapshot, PyTorchToBurnAdapter, SafetensorsStore};
+use crate::{
+    BurnToPyTorchAdapter, ModuleSnapshot, ModuleStore, PyTorchToBurnAdapter, SafetensorsStore,
+};
 use burn_core::module::{Module, Param};
 use burn_nn::{Linear, LinearConfig};
 use burn_tensor::Tensor;
@@ -190,4 +192,158 @@ fn adapter_with_pytorch_import() {
     // Should load some tensors (fc1 if it exists in the file)
     // This mainly tests that the adapter works with real PyTorch files
     assert!(!result.applied.is_empty() || !result.missing.is_empty());
+}
+
+#[test]
+fn half_precision_adapter_round_trip() {
+    use crate::HalfPrecisionAdapter;
+    use burn_tensor::DType;
+
+    let device = Default::default();
+    let model = TestModel::<TestBackend>::new(&device);
+
+    // Save with HalfPrecisionAdapter (F32 -> F16)
+    let adapter = HalfPrecisionAdapter::new();
+    let mut save_store = SafetensorsStore::from_bytes(None).with_to_adapter(adapter.clone());
+    model.save_into(&mut save_store).unwrap();
+
+    // Verify Linear tensors are F16, raw params stay F32 (no recognized module type)
+    let save_bytes = match &save_store {
+        SafetensorsStore::Memory(p) => p.data().unwrap().as_ref().clone(),
+        _ => panic!("Expected memory store"),
+    };
+    let mut inspect_store = SafetensorsStore::from_bytes(Some(save_bytes.clone()));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (name, snapshot) in snapshots.iter() {
+        if name.starts_with("linear") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F16,
+                "Linear tensor '{}' should be F16",
+                name
+            );
+        } else {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F32,
+                "Raw param '{}' should stay F32",
+                name
+            );
+        }
+    }
+
+    // Load back with same adapter (F16 -> F32)
+    let mut load_store = SafetensorsStore::from_bytes(Some(save_bytes)).with_from_adapter(adapter);
+
+    let mut model2 = TestModel::<TestBackend>::new(&device);
+    let result = model2.load_from(&mut load_store).unwrap();
+
+    assert!(!result.applied.is_empty());
+
+    // Verify values are close (F32 -> F16 -> F32 has rounding)
+    let w1 = model.linear.weight.val().to_data().to_vec::<f32>().unwrap();
+    let w2 = model2
+        .linear
+        .weight
+        .val()
+        .to_data()
+        .to_vec::<f32>()
+        .unwrap();
+    for (a, b) in w1.iter().zip(w2.iter()) {
+        assert!(
+            (a - b).abs() < 0.01,
+            "Weight values differ too much after F16 round-trip: {} vs {}",
+            a,
+            b
+        );
+    }
+}
+
+#[test]
+fn half_precision_adapter_without_module() {
+    use crate::HalfPrecisionAdapter;
+    use burn_nn::{LayerNorm, LayerNormConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct MixedModel<B: Backend> {
+        linear: Linear<B>,
+        norm: LayerNorm<B>,
+    }
+
+    let device = Default::default();
+    let model = MixedModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+        norm: LayerNormConfig::new(2).init(&device),
+    };
+
+    // Save: exclude LayerNorm from half-precision conversion
+    let adapter = HalfPrecisionAdapter::new().without_module("LayerNorm");
+    let mut save_store = SafetensorsStore::from_bytes(None).with_to_adapter(adapter);
+    model.save_into(&mut save_store).unwrap();
+
+    // Verify: Linear tensors are F16, LayerNorm tensors remain F32
+    let save_bytes = match &save_store {
+        SafetensorsStore::Memory(p) => p.data().unwrap().as_ref().clone(),
+        _ => panic!("Expected memory store"),
+    };
+    let mut inspect_store = SafetensorsStore::from_bytes(Some(save_bytes));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (name, snapshot) in snapshots {
+        if name.starts_with("linear") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F16,
+                "Linear tensor '{}' should be F16",
+                name
+            );
+        } else if name.starts_with("norm") {
+            assert_eq!(
+                snapshot.dtype,
+                DType::F32,
+                "LayerNorm tensor '{}' should stay F32",
+                name
+            );
+        }
+    }
+}
+
+#[test]
+fn half_precision_adapter_default_converts_layer_norm() {
+    use crate::HalfPrecisionAdapter;
+    use burn_nn::{LayerNorm, LayerNormConfig};
+    use burn_tensor::DType;
+
+    #[derive(Module, Debug)]
+    struct NormModel<B: Backend> {
+        linear: Linear<B>,
+        norm: LayerNorm<B>,
+    }
+
+    let device = Default::default();
+    let model = NormModel::<TestBackend> {
+        linear: LinearConfig::new(4, 2).with_bias(true).init(&device),
+        norm: LayerNormConfig::new(2).init(&device),
+    };
+
+    // Default adapter converts LayerNorm
+    let adapter = HalfPrecisionAdapter::new();
+    let mut save_store = SafetensorsStore::from_bytes(None).with_to_adapter(adapter);
+    model.save_into(&mut save_store).unwrap();
+
+    let save_bytes = match &save_store {
+        SafetensorsStore::Memory(p) => p.data().unwrap().as_ref().clone(),
+        _ => panic!("Expected memory store"),
+    };
+    let mut inspect_store = SafetensorsStore::from_bytes(Some(save_bytes));
+    let snapshots = inspect_store.get_all_snapshots().unwrap();
+    for (name, snapshot) in snapshots {
+        assert_eq!(
+            snapshot.dtype,
+            DType::F16,
+            "All tensors should be F16 by default, but '{}' is {:?}",
+            name,
+            snapshot.dtype
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Replace generic `CastDTypeAdapter` with specialized `HalfPrecisionAdapter` for F32/F16 mixed-precision storage
- Auto-detects conversion direction from snapshot dtype: same adapter instance works for both save (`F32->F16`) and load (`F16->F32`)
- Ships with smart defaults: 14 module types converted (Linear, Embedding, Conv*, LayerNorm, GroupNorm, InstanceNorm, RmsNorm, PRelu), BatchNorm excluded due to `running_var` underflow in F16
- Builder API: `with_module()` / `without_module()` for customization

## Test plan

- [x] `cargo test -p burn-store` - 360 tests pass (22 new adapter tests)
- [x] `cargo clippy -p burn-store` - zero warnings
- [x] `cargo run -p burn-store --example half_precision` - runs correctly
- [x] Doc-tests pass for all 3 code examples in `HalfPrecisionAdapter` docs

Closes https://github.com/tracel-ai/burn-onnx/issues/247