### PR TITLE
Make Param<T> Sync for parallel model inference

### DIFF
--- a/crates/burn-core/src/module/param/base.rs
+++ b/crates/burn-core/src/module/param/base.rs
@@ -1,8 +1,8 @@
 use super::ParamId;
+use super::sync_once_cell::SyncOnceCell;
 use alloc::{boxed::Box, format};
 use burn_std::stub::RwLock;
 use burn_tensor::Shape;
-use core::cell::OnceCell;
 use core::ops::Deref;
 
 #[cfg(target_has_atomic = "ptr")]
@@ -34,20 +34,20 @@ fn new_mapper<T, F: Fn(T) -> T + Send + Sync + 'static>(func: F) -> Mapper<T> {
 ///
 /// # Core Lazy Initialization Architecture
 ///
-/// `Param<T>` has a dual-state design using `OnceCell<T>`:
+/// `Param<T>` has a dual-state design using `SyncOnceCell<T>`:
 ///
 /// ## State Management
 ///
 /// **Two possible states:**
 ///
-/// 1. **Initialized**: `state: OnceCell<T>` contains value, `initialization: None`
+/// 1. **Initialized**: `state: SyncOnceCell<T>` contains value, `initialization: None`
 /// 2. **Uninitialized (Lazy)**: `state` is empty, `initialization: Some(RwLock<Option<Uninitialized<T>>>)`
 pub struct Param<T: Parameter> {
     /// The unique ID of this parameter. This is used by eg. optimizers to associate a gradient with a specific parameter.
     pub id: ParamId,
-    /// The OnceCell holding the initialized parameter value.
+    /// The SyncOnceCell holding the initialized parameter value.
     /// Empty for uninitialized parameters, populated after first access or explicit initialization.
-    pub(crate) state: OnceCell<T>,
+    pub(crate) state: SyncOnceCell<T>,
     /// The deferred initialization state for lazy parameters.
     ///
     /// **State Transitions:**
@@ -146,7 +146,7 @@ pub trait Parameter: Clone + core::fmt::Debug + Send {
 pub(crate) struct Uninitialized<P: Parameter> {
     /// The initialization function. Called with `(device, is_require_grad) -> Parameter`.
     /// This function is consumed during initialization via `FnOnce`.
-    init: Box<dyn FnOnce(&P::Device, bool) -> P + Send>,
+    init: Box<dyn FnOnce(&P::Device, bool) -> P + Send + Sync>,
     /// The target device on which the parameter should be initialized.
     /// Used by `lazy_device()` to provide device information without triggering initialization.
     pub(crate) device: P::Device,
@@ -175,7 +175,7 @@ impl<T: Parameter> Param<T> {
         let require_grad = value.is_require_grad();
         Self {
             id,
-            state: OnceCell::from(value),
+            state: SyncOnceCell::initialized(value),
             initialization: None,
             param_mapper: Default::default(),
             require_grad,
@@ -191,11 +191,11 @@ impl<T: Parameter> Param<T> {
         shape: Shape,
     ) -> Self
     where
-        F: FnOnce(&T::Device, bool) -> T + Send + 'static,
+        F: FnOnce(&T::Device, bool) -> T + Send + Sync + 'static,
     {
         Self {
             id,
-            state: OnceCell::new(),
+            state: SyncOnceCell::new(),
             initialization: Some(RwLock::new(Some(Uninitialized {
                 init: Box::new(init),
                 device,
@@ -256,7 +256,7 @@ impl<T: Parameter> Param<T> {
 
         Self {
             id,
-            state: OnceCell::from(tensor),
+            state: SyncOnceCell::initialized(tensor),
             initialization: None,
             param_mapper,
             require_grad,
@@ -271,7 +271,7 @@ impl<T: Parameter> Param<T> {
         let require_grad = value.is_require_grad();
         Self {
             id,
-            state: OnceCell::from(value),
+            state: SyncOnceCell::initialized(value),
             initialization: None,
             param_mapper,
             require_grad,
@@ -293,7 +293,7 @@ impl<T: Parameter> Param<T> {
     }
 
     /// Execute the given function on the inner value.
-    pub fn init_mapper<F: FnOnce(T) -> T + Send + 'static>(self, func: F) -> Self
+    pub fn init_mapper<F: FnOnce(T) -> T + Send + Sync + 'static>(self, func: F) -> Self
     where
         T: 'static,
     {
@@ -307,7 +307,7 @@ impl<T: Parameter> Param<T> {
         match init.as_mut() {
             Some(value) => {
                 #[allow(clippy::type_complexity)]
-                let mut prev: Box<dyn FnOnce(&T::Device, bool) -> T + Send> =
+                let mut prev: Box<dyn FnOnce(&T::Device, bool) -> T + Send + Sync> =
                     Box::new(|_, _| panic!("Fake func to not have null ref."));
                 core::mem::swap(&mut prev, &mut value.init);
 
@@ -420,5 +420,23 @@ impl<T: Parameter> Deref for Param<T> {
             let state = result.take().expect("Should exist when not initialized");
             state.initialize()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn_tensor::{Tensor, backend::Backend};
+
+    // Param<T> should be Sync so that models can be shared across threads
+    // (e.g. parallel inference with rayon).
+    fn _assert_sync<T: Sync>() {}
+
+    #[test]
+    fn param_is_sync() {
+        fn check<B: Backend>() {
+            _assert_sync::<Param<Tensor<B, 2>>>();
+        }
+        check::<burn_ndarray::NdArray>();
     }
 }

--- a/crates/burn-core/src/module/param/mod.rs
+++ b/crates/burn-core/src/module/param/mod.rs
@@ -3,6 +3,7 @@ mod constant;
 mod id;
 mod primitive;
 mod running;
+mod sync_once_cell;
 mod tensor;
 mod visitor;
 

--- a/crates/burn-core/src/module/param/sync_once_cell.rs
+++ b/crates/burn-core/src/module/param/sync_once_cell.rs
@@ -1,0 +1,57 @@
+//! A thread-safe `OnceCell` that works in both `std` and `no_std` environments.
+//!
+//! Wraps `std::sync::OnceLock` (with `std`) or `spin::Once` (without `std`) behind
+//! a unified API. This makes `Param<T>` `Sync` so models can be shared across threads
+//! for parallel inference.
+
+#[cfg(feature = "std")]
+use std::sync::OnceLock as Inner;
+
+#[cfg(not(feature = "std"))]
+use spin::Once as Inner;
+
+pub(crate) struct SyncOnceCell<T>(Inner<T>);
+
+impl<T: core::fmt::Debug> core::fmt::Debug for SyncOnceCell<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("SyncOnceCell").field(&self.get()).finish()
+    }
+}
+
+impl<T> SyncOnceCell<T> {
+    /// Create a new empty cell.
+    pub fn new() -> Self {
+        Self(Inner::new())
+    }
+
+    /// Create a cell pre-populated with `value`.
+    pub fn initialized(value: T) -> Self {
+        #[cfg(feature = "std")]
+        {
+            let cell = Inner::new();
+            cell.set(value).ok().expect("cell was just created");
+            Self(cell)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            Self(Inner::initialized(value))
+        }
+    }
+
+    /// Returns `Some(&T)` if initialized, `None` otherwise.
+    pub fn get(&self) -> Option<&T> {
+        self.0.get()
+    }
+
+    /// Returns `&T`, initializing with `f` on first call.
+    pub fn get_or_init<F: FnOnce() -> T>(&self, f: F) -> &T {
+        #[cfg(feature = "std")]
+        {
+            self.0.get_or_init(f)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            self.0.call_once(f)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `core::cell::OnceCell` (!Sync) in `Param<T>` with a thread-safe `SyncOnceCell` wrapper over `std::sync::OnceLock` / `spin::Once`
- Add `Sync` bound to initialization closures in `Uninitialized`, `Param::uninitialized`, and `init_mapper`
- Models can now be shared across threads via `&model` for parallel inference (e.g. with rayon)

### Problem

`Param<T>` used `core::cell::OnceCell<T>` for lazy parameter initialization. `OnceCell` is `!Sync`, which made all modules `!Sync`, preventing parallel inference patterns like:

```rust
let results: Vec<_> = inputs.into_par_iter().map(|input| {
    model.forward(input)  // ERROR: model is !Sync
}).collect();
```

### Fix

`SyncOnceCell` wraps `OnceLock` (std) or `spin::Once` (no_std) with a unified API. The overhead on the already-initialized fast path is a single atomic load, negligible compared to tensor operations.

## Test plan

- [x] New compile-time test `param_is_sync` verifies `Param<Tensor<B, 2>>: Sync`
- [x] All 11 existing param tests pass
- [x] `burn-nn` and `burn-store` compile (downstream callers of `Param::uninitialized` and `init_mapper`)
- [x] Rayon parallel inference example compiles and runs successfully